### PR TITLE
Use external_host in instead of external_url for credhub/uaa communication

### DIFF
--- a/operations/add-credhub-uaa-to-web.yml
+++ b/operations/add-credhub-uaa-to-web.yml
@@ -124,7 +124,7 @@
           passphrase: ((encryption-keys-passphrase))
         active_key_label: 'KEY-1'
       uaa:
-        url: &uaa-url ((external_url)):8443
+        url: &uaa-url https://((external_host)):8443
         port: 8181
         logging_level: INFO
         scim:


### PR DESCRIPTION
This allows you to use ports other than port 443 for concourse. I don't see any negative side-effects of using external_host vs external_url.