### PR TITLE
bosh dpeloyment using concourse user and postgres password variable

### DIFF
--- a/operations/backup-atc-db.yml
+++ b/operations/backup-atc-db.yml
@@ -8,5 +8,5 @@
         database: atc
         sslmode: disable
         role:
-          name: atc
-          password: ((atc-db-password))
+          name: concourse
+          password: ((postgres_password))


### PR DESCRIPTION
for concourse backup, user concourse is created but the ops file are referencing an atc user that is not valid
password should also reference postgres_password variable from the concourse bosh deployment repo