### PR TITLE
Add 'key_properties' parent key

### DIFF
--- a/operations/add-credhub-uaa-to-web.yml
+++ b/operations/add-credhub-uaa-to-web.yml
@@ -209,7 +209,8 @@
         encryption:
           keys:
           - provider_name: int
-            encryption_password: ((credhub-encryption-password))
+            key_properties:
+              encryption_password: ((credhub-encryption-password))
             active: true
           providers:
           - name: int


### PR DESCRIPTION
This commit adds the `key_properties` parent key for the `int`
internal provider. Specifically, this corrects the following from
occurring when the pre-start script runs for Credhub on the `web`
VM.

```
goroutine 1 [running]:
main.main()
	/var/vcap/data/compile/configurator/src/configurator/main.go:101 +0x196f
panic: Internal providers require encryption_password.
```

This is based on the [Credhub job spec](https://github.com/pivotal-cf/credhub-release/blob/master/jobs/credhub/spec#L93).